### PR TITLE
ツイートできない場合は、重複制限の回避を目指しリトライする

### DIFF
--- a/tweet.py
+++ b/tweet.py
@@ -6,6 +6,7 @@ import time
 
 
 def get_one_tweet() -> tuple[str, int]:
+    """ツイート一覧からランダムに 1 ツイートを取得し、index とともに返す"""
     f = open("tweets.txt", "r", encoding="utf-8")
     lines = f.readlines()
     idx = randint(0, len(lines) - 1)


### PR DESCRIPTION
## WHY
- #7 に対処したい

## WHAT

- ツイートが失敗した場合、最大5回まで試す (その際、一度失敗したツイートは避けるよう、行番号で管理)
  -  12 時間以内のツイート (直近 4 ツイート) に重複制限がかかっていそうなので、5 回で必ず回避可能
- 5 回すべて失敗した場合、エラーを raise する
- 1 回でも失敗した場合は、ログに何回目か・ツイートの index・失敗理由を出力する (print 文に書けば出るはず [1]) 。

## 参考
- https://chat.openai.com/c/d8b676b7-6190-4729-ae75-470960ad58db
  - tweepy のエラー処理には chatgpt 含め `tweepy.TweepError` を使う記述が多いが、バージョン 4 から `tweepy.TweepyException` に変更されているので注意
- [1] https://chat.openai.com/c/03e3cd74-1880-4f0b-b456-3c22267f49f3