### PR TITLE
GitHub Actions に時間打ち切りの機能を付ける

### DIFF
--- a/.github/workflows/run_pytest_on_pr_merge.yaml
+++ b/.github/workflows/run_pytest_on_pr_merge.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tweet_periodically.yaml
+++ b/.github/workflows/tweet_periodically.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## WHY

GA で何らかの不具合で、動いていないのに失敗せず時間経過してしまった場合、無料枠を使い切ってしまう可能性がある
一応 6 時間で打ち切られるらしいが、もっと短くしたい

## WHAT

定期ツイートするものも、マージ後にテストを走らせるものも、通常 30 秒以内で終わっているので、2 分にタイムアウト (時間打ち切り) を設定する

## 参考

- https://qiita.com/chihiro/items/341b579a07fac35fd1d7
- 別リポジトリ: https://github.com/tomii9273/atcoder_type_checker/pull/92