### PR TITLE
yaml などを prettier でフォーマット

### DIFF
--- a/.github/workflows/run_pytest_on_pr_merge.yaml
+++ b/.github/workflows/run_pytest_on_pr_merge.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tweet_periodically.yaml
+++ b/.github/workflows/tweet_periodically.yaml
@@ -2,7 +2,7 @@ name: tweet_periodically
 on:
   schedule:
     # 日本時間でも UTC でも (3 の倍数) 時 00 分に実行
-    - cron: '0 */3 * * *'
+    - cron: "0 */3 * * *"
 
 jobs:
   build:
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -25,4 +25,4 @@ jobs:
         run: |
           python tweet.py ${{secrets.CONSUMER_KEY}} ${{secrets.CONSUMER_SECRET}} ${{secrets.ACCESS_TOKEN}} ${{secrets.ACCESS_TOKEN_SECRET}}
         env:
-          TZ: 'Asia/Tokyo'
+          TZ: "Asia/Tokyo"

--- a/chinese_mahjong_bot.code-workspace
+++ b/chinese_mahjong_bot.code-workspace
@@ -1,12 +1,12 @@
 {
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {
-		"terminal.integrated.cwd": ".",
-		"terminal.integrated.scrollback": 200000,
-		"python.languageServer": "Pylance",
-	}
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "terminal.integrated.cwd": ".",
+    "terminal.integrated.scrollback": 200000,
+    "python.languageServer": "Pylance"
+  }
 }


### PR DESCRIPTION
## WHY・WHAT

prettier を導入してから、vscode で yaml などを保存すると、(ユーザーの) 設定 (`settings.json`) で html と css のみを指定しているにもかかわらず、自動フォーマットされる。
別リポジトリで色々試したが [1]、拡張機能を止めない限り常にされるらしい。

ただ問題はなく、むしろありがたいので、GA の yaml とワークスペースファイル (これは json っぽいのになぜかフォーマットされる、他の json はされない) を一度全部フォーマットする。

## 参考

- [1] https://github.com/tomii9273/atcoder_type_checker/pull/102